### PR TITLE
Updates

### DIFF
--- a/mtpy/core/mt.py
+++ b/mtpy/core/mt.py
@@ -797,6 +797,28 @@ class MT(TF, MTLocation):
 
             self.tipper_model_error = t_model_error
 
+    def find_flipped_phase(self):
+        """
+        identify if the off-diagonal components are flipped from traditional
+        quadrants.  xy should be in the 1st quadarant (0-90 deg) and yx
+        should be in the 3rd quadrant (-180 to -90 deg)
+
+        :return: a dictionary of components with a bool for flipped or not
+         if flipped return value is True
+        :rtype: dict
+
+        """
+
+        flip_dict = {"zxy": False, "zyx": False}
+
+        if self.Z.phase_xy.mean() < 0:
+            flip_dict["zxy"] = True
+
+        if self.Z.phase_yx.mean() > -90:
+            flip_dict["zyx"] = True
+
+        return flip_dict
+
     def flip_phase(
         self,
         zxx=False,

--- a/mtpy/core/mt_data.py
+++ b/mtpy/core/mt_data.py
@@ -177,7 +177,6 @@ class MTData(OrderedDict, MTStations):
         for key in self._copy_attrs:
             value = getattr(self, key)
             setattr(result, key, deepcopy(value, memo))
-            print(key, value)
 
         for mt_obj in self.values():
             result.add_station(mt_obj.copy(), compute_relative_location=False)

--- a/mtpy/core/mt_data.py
+++ b/mtpy/core/mt_data.py
@@ -172,10 +172,12 @@ class MTData(OrderedDict, MTStations):
         """
         cls = self.__class__
         result = cls.__new__(cls)
+        result.__init__()
         memo[id(self)] = result
         for key in self._copy_attrs:
             value = getattr(self, key)
             setattr(result, key, deepcopy(value, memo))
+            print(key, value)
 
         for mt_obj in self.values():
             result.add_station(mt_obj.copy(), compute_relative_location=False)

--- a/mtpy/gis/raster_tools.py
+++ b/mtpy/gis/raster_tools.py
@@ -73,3 +73,6 @@ def array2raster(
         transform=transform,
     ) as dataset:
         dataset.write(array, 1)
+
+
+# def dem_to_ply(geotiff_file, save_path=None):

--- a/mtpy/modeling/modem/data.py
+++ b/mtpy/modeling/modem/data.py
@@ -23,6 +23,7 @@ from mtpy.core.mt_dataframe import MTDataFrame
 from mtpy.core.mt_location import MTLocation
 from mtpy.modeling.errors import ModelErrors
 
+
 # =============================================================================
 class Data:
     """
@@ -201,7 +202,6 @@ class Data:
     """
 
     def __init__(self, dataframe=None, center_point=None, **kwargs):
-
         self.logger = logger
 
         self.dataframe = dataframe
@@ -668,9 +668,11 @@ class Data:
 
         ## check for zeros in model error
         for comp in ["zxx", "zxy", "zyx", "zyy", "tzx", "tzy"]:
-            find_zeros = np.where(self.dataframe[f"{comp}_model_error"] == 0)[
-                0
-            ]
+            find_zeros = np.where(self.dataframe[f"{comp}_model_error"] == 0)[0]
+            find_zeros_data = np.where(self.dataframe[f"{comp}"] == 0)[0]
+
+            if find_zeros.shape == find_zeros_data.shape:
+                continue
             if find_zeros.shape[0] > 0:
                 if comp in ["zxx", "zxy", "zyx", "zyy"]:
                     error_percent = self.z_model_error.error_value
@@ -702,7 +704,6 @@ class Data:
                 < tol
             )[0]
             if find_small.shape[0] > 0:
-
                 if comp.startswith("z"):
                     error_percent = self.z_model_error.error_value
                 elif comp.startswith("t"):
@@ -861,8 +862,7 @@ class Data:
                         self.wave_sign_tipper = hline[hline.find("(") + 1]
 
                 elif (
-                    len(hline[1:].strip().split()) >= 2
-                    and hline.count(".") > 0
+                    len(hline[1:].strip().split()) >= 2 and hline.count(".") > 0
                 ):
                     value_list = [
                         float(value) for value in hline[1:].strip().split()
@@ -937,7 +937,6 @@ class Data:
                         if key in ["model_epsg"]:
                             setattr(self.center_point, "utm_epsg", value)
                         elif "error" in key:
-
                             setattr(
                                 obj,
                                 item_dict[key],
@@ -1145,9 +1144,7 @@ class Data:
             lines = fid.readlines()
 
         def fix_line(line_list):
-            return (
-                " ".join("".join(line_list).replace("\n", "").split()) + "\n"
-            )
+            return " ".join("".join(line_list).replace("\n", "").split()) + "\n"
 
         h1 = fix_line(lines[0:n])
         h2 = fix_line(lines[n : 2 * n])

--- a/tests/core/test_mt_collection.py
+++ b/tests/core/test_mt_collection.py
@@ -143,20 +143,20 @@ class TestMTCollection(unittest.TestCase):
                     4: 534.0,
                     5: 10.0,
                     6: 77.025,
-                    7: 948.158935547,
-                    8: 2352.3984375,
+                    7: 0.0,
+                    8: 0.0,
                     9: 0.0,
                     10: 2489.0,
                     11: 181.0,
                     12: 175.27,
                     13: 122.0,
                     14: 0.0,
-                    15: 1674.992797852,
-                    16: 1674.992797852,
+                    15: 0.0,
+                    16: 0.0,
                     17: 0.0,
-                    18: 1414.37487793,
+                    18: 0.0,
                     19: 1548.1,
-                    20: 1954.861816406,
+                    20: 0.0,
                 },
                 "tf_id": {
                     0: "14-IEB0537A",
@@ -446,6 +446,12 @@ class TestMTCollection(unittest.TestCase):
         for tf_fn in self.fn_list:
             original = MT(tf_fn)
             original.read()
+            if original.station_metadata.location.elevation == 0:
+                original.station_metadata.location.elevation = (
+                    self.true_dataframe[
+                        self.true_dataframe.station == original.station
+                    ].elevation
+                )
             for key, value in mt_data_01.items():
                 if original.station in key:
                     original.survey = validate_name(value.survey)
@@ -484,6 +490,7 @@ class TestMTCollection(unittest.TestCase):
                 original.station_metadata.transfer_function.processing_type = (
                     None
                 )
+
             mt_data_02.add_station(original, compute_relative_location=False)
         mt_data_02.compute_relative_locations()
 

--- a/tests/core/transfer_function/test_tf_base.py
+++ b/tests/core/transfer_function/test_tf_base.py
@@ -441,6 +441,11 @@ class TestTFInterpolationFillNans(unittest.TestCase):
             self.period
         )
 
+        self.new_period = np.logspace(-4, 4, 24)
+        self.tf_interpolated_different_period = self.tf_base.interpolate(
+            self.new_period
+        )
+
     def test_find_nans_index(self):
         true_index = self.tf_base._find_nans_index(
             self.tf_base._dataset.transfer_function
@@ -471,12 +476,71 @@ class TestTFInterpolationFillNans(unittest.TestCase):
             ),
         )
 
-    # def test_same_periods(self):
-    #     new_tf = self.tf_base.interpolate(self.period)
-    #     self.assertTupleEqual(
-    #         np.where(np.nan_to_num(self.tf) == 0),
-    #         np.where(np.nan_to_num(new_tf._dataset.transfer_function) == 0),
-    #     )
+    def test_same_tf(self):
+        self.assertEqual(
+            True,
+            np.all(
+                np.isclose(
+                    np.nan_to_num(self.tf_base._dataset.transfer_function),
+                    np.nan_to_num(
+                        self.tf_interpolated_same_period._dataset.transfer_function
+                    ),
+                ),
+            ),
+        )
+
+    def test_same_tf_error(self):
+        self.assertEqual(
+            True,
+            np.all(
+                np.isclose(
+                    np.nan_to_num(
+                        self.tf_base._dataset.transfer_function_error
+                    ),
+                    np.nan_to_num(
+                        self.tf_interpolated_same_period._dataset.transfer_function_error
+                    ),
+                ),
+            ),
+        )
+
+    def test_same_tf_model_error(self):
+        self.assertEqual(
+            True,
+            np.all(
+                np.isclose(
+                    np.nan_to_num(
+                        self.tf_base._dataset.transfer_function_model_error
+                    ),
+                    np.nan_to_num(
+                        self.tf_interpolated_same_period._dataset.transfer_function_model_error
+                    ),
+                ),
+            ),
+        )
+
+    def test_different_period_index(self):
+        true_index = self.tf_base._find_nans_index(
+            self.tf_base._dataset.transfer_function
+        )
+
+        new_index = self.tf_interpolated_different_period._find_nans_index(
+            self.tf_interpolated_different_period._dataset.transfer_function
+        )
+
+        for true_entry, new_entry in zip(true_index, new_index):
+            with self.subTest(
+                f"period_min: in = {true_entry['input']} out = {true_entry['output']}"
+            ):
+                self.assertTrue(
+                    true_entry["period_min"] <= new_entry["period_min"]
+                )
+            with self.subTest(
+                f"period_max: in = {true_entry['input']} out = {true_entry['output']}"
+            ):
+                self.assertTrue(
+                    true_entry["period_max"] >= new_entry["period_max"]
+                )
 
 
 # =============================================================================

--- a/tests/core/transfer_function/test_tf_base.py
+++ b/tests/core/transfer_function/test_tf_base.py
@@ -458,12 +458,25 @@ class TestTFInterpolationFillNans(unittest.TestCase):
             with self.subTest(entry_count):
                 self.assertDictEqual(true_entry, new_entry)
 
-    def test_same_periods(self):
-        new_tf = self.tf_base.interpolate(self.period)
-        self.assertTupleEqual(
-            np.where(np.nan_to_num(self.tf) == 0),
-            np.where(np.nan_to_num(new_tf._dataset.transfer_function) == 0),
+    def test_backfill_nans(self):
+        new_tf = self.tf_base.interpolate(self.period, extrapolate=True)
+        new_tf_nans = self.tf_base._backfill_nans(
+            self.tf_base._dataset.transfer_function,
+            new_tf._dataset.transfer_function,
         )
+        self.assertEqual(
+            True,
+            np.all(
+                np.isclose(np.nan_to_num(self.tf), np.nan_to_num(new_tf_nans))
+            ),
+        )
+
+    # def test_same_periods(self):
+    #     new_tf = self.tf_base.interpolate(self.period)
+    #     self.assertTupleEqual(
+    #         np.where(np.nan_to_num(self.tf) == 0),
+    #         np.where(np.nan_to_num(new_tf._dataset.transfer_function) == 0),
+    #     )
 
 
 # =============================================================================

--- a/tests/core/transfer_function/test_tf_base.py
+++ b/tests/core/transfer_function/test_tf_base.py
@@ -232,7 +232,10 @@ class TestTFRotation(unittest.TestCase):
             ) = rotate_matrix_with_errors(
                 np.ones((2, 2), dtype=complex), 30, np.ones((2, 2)) * 0.25
             )
-            (_, self.true_rot_tf_model_error[ii],) = rotate_matrix_with_errors(
+            (
+                _,
+                self.true_rot_tf_model_error[ii],
+            ) = rotate_matrix_with_errors(
                 np.ones((2, 2), dtype=complex), 30, np.ones((2, 2)) * 0.5
             )
 
@@ -347,7 +350,6 @@ class TestTFInterpolation(unittest.TestCase):
             "transfer_function_error",
             "transfer_function_model_error",
         ]:
-
             with self.subTest(key):
                 self.assertEqual(
                     (interp_ds._dataset[key] == interp_tf._dataset[key]).all(),
@@ -365,7 +367,6 @@ class TestTFInterpolation(unittest.TestCase):
             "transfer_function_error",
             "transfer_function_model_error",
         ]:
-
             with self.subTest(key):
                 self.assertEqual(
                     (interp_ds._dataset[key] == interp_tf._dataset[key]).all(),
@@ -383,7 +384,6 @@ class TestTFInterpolation(unittest.TestCase):
             "transfer_function_error",
             "transfer_function_model_error",
         ]:
-
             with self.subTest(key):
                 self.assertEqual(
                     (interp_ds._dataset[key] == interp_tf._dataset[key]).all(),
@@ -401,12 +401,69 @@ class TestTFInterpolation(unittest.TestCase):
             "transfer_function_error",
             "transfer_function_model_error",
         ]:
-
             with self.subTest(key):
                 self.assertEqual(
                     (interp_ds._dataset[key] == interp_tf._dataset[key]).all(),
                     True,
                 )
+
+
+class TestTFInterpolationFillNans(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        self.maxDiff = None
+        self.n = 12
+        self.period = np.logspace(-3, 3, self.n)
+        self.t = np.linspace(0, 24, 4 * self.n) * 0.1
+        self.tf = np.array(
+            [
+                np.cos(pp * np.pi * 2 * 10 * self.t)
+                + 1j * np.sin(pp * np.pi * 2 * 10 * self.t)
+                for pp in self.period
+            ]
+        ).sum(axis=0)
+
+        self.tf = self.tf.reshape((self.n, 2, 2))
+        self.tf[0:1] = np.nan + 1j * np.nan
+        self.tf[-2:] = np.nan + 1j * np.nan
+
+        self.tf_error = np.abs(self.tf) * 0.05
+        self.tf_model_error = np.abs(self.tf) * 0.10
+
+        self.tf_base = TFBase(
+            tf=self.tf,
+            tf_error=self.tf_error,
+            tf_model_error=self.tf_model_error,
+            frequency=1.0 / self.period,
+        )
+
+        self.tf_interpolated_same_period = self.tf_base.interpolate(
+            self.period
+        )
+
+    def test_find_nans_index(self):
+        true_index = self.tf_base._find_nans_index(
+            self.tf_base._dataset.transfer_function
+        )
+
+        new_index = self.tf_interpolated_same_period._find_nans_index(
+            self.tf_interpolated_same_period._dataset.transfer_function
+        )
+
+        with self.subTest("list length"):
+            self.assertEqual(len(true_index), len(new_index))
+
+        entry_count = 0
+        for true_entry, new_entry in zip(true_index, new_index):
+            with self.subTest(entry_count):
+                self.assertDictEqual(true_entry, new_entry)
+
+    def test_same_periods(self):
+        new_tf = self.tf_base.interpolate(self.period)
+        self.assertTupleEqual(
+            np.where(np.nan_to_num(self.tf) == 0),
+            np.where(np.nan_to_num(new_tf._dataset.transfer_function) == 0),
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
- Interpolation: need to reinsert nan's from the original data based on period.  When we do the interpolation with xarray we first to a `interpolate_na` which removes the nans at the beginning and end of the data and replaces them with extrapolated values, which are usually not great.  Therefore we need to reinsert the nan's at the beginning and end of the interpolated data to keep true to the data.  The keyword `extrapolate=True` allows the user to skip this step, but is set to `False` by default.
- Adjust the order of initiation with `MT` such that keyword arguments can be passed to the inherited `TF` object.  This speeds up reading and initialization.  Currently the initialization of `MT` runs `_initialize_xarray` twice and that is costly.  