### PR TITLE
Added to ModEM module docs

### DIFF
--- a/mtpy/modeling/modem/control_fwd.py
+++ b/mtpy/modeling/modem/control_fwd.py
@@ -7,6 +7,7 @@ ModEM
 
 # revised by JP 2017
 # revised by AK 2017 to bring across functionality from ak branch
+# revised by OA 2024 to update docs
 
 """
 # =============================================================================
@@ -21,10 +22,28 @@ from mtpy.utils import exceptions as mtex
 
 class ControlFwd:
     """
-    read and write control file for
+    Reads and writes control files for ModEM to control how the forward solver 
+    starts and how it is run.
 
-    This file controls how the inversion starts and how it is run
-
+    ==================== ======================================================
+    Attributes           Description
+    ==================== ======================================================
+    num_qmr_iter         Number of QMR iterations per divergence correction. 
+                         int, *default* is 40 
+    max_num_div_calls    Maximum number of divergence correction calls. int, 
+                         *default* is 20
+    max_num_div_iters    Maximum number of divergence correction iterations. 
+                         int, *default* is 100
+    misfit_tol_fwd       Misfit tolerance for EM forward solver. float, 
+                         *default* is 1e-07
+    misfit_tol_adj       Misfit tolerance for EM adjoint solver. float, 
+                         *default* is 1e-07
+    misfit_tol_div       Misfit tolerance for divergence correction. float, 
+                         *default*  is 1e-05
+    save_path            Path at which to save the control file. PosixPath, 
+                         *default* is current working directory.
+    fn_basename          Name of the control file. str, *default* is 
+                         'control.fwd',
     """
 
     def __init__(self, **kwargs):

--- a/mtpy/modeling/modem/control_inv.py
+++ b/mtpy/modeling/modem/control_inv.py
@@ -7,6 +7,7 @@ ModEM
 
 # revised by JP 2017
 # revised by AK 2017 to bring across functionality from ak branch
+# revised by OA 2024 to update docs
 
 """
 # =============================================================================
@@ -21,12 +22,35 @@ from mtpy.utils import exceptions as mtex
 
 class ControlInv(object):
     """
-    read and write control file for how the inversion starts and how it is run
+    Reads and writes control files for ModEM to control how the inversion 
+    starts and how it is run.
 
+    ==================== ======================================================
+    Attributes           Description
+    ==================== ======================================================
+    output_fn            Model and data output file name "prefix phrase", i.e. 
+                         written to the front of ModEM output file names before 
+                         the iteration number and file extension. str, 
+                         *default* is 'MODULAR_NLCG'
+    lambda_initial       Initial damping factor lambda. int, *default* is 10
+    lambda_step          To update lambda, divide by this value. int, *default* 
+                         is 10
+    model_search_step    Initial search step in model units. int, *default* is 
+                         1
+    rms_reset_search     Restart when rms diff is less than this value. float, 
+                         *default* is 0.002
+    rms_target           Exit search when rms is less than this value. float, 
+                         *default* is 1.05
+    lambda_exit          Exit when lambda is less than this value. float, 
+                         *default* is 0.0001
+    max_iterations       Maximum number of iterations. int, *default* is 100
+    save_path            Path at which to save the control file. PosixPath, 
+                         *default* is current working directory
+    fn_basename          Name of the control file. str, *default* is 
+                         'control.inv'
     """
 
     def __init__(self, **kwargs):
-
         self.output_fn = "MODULAR_NLCG"
         self.lambda_initial = 10
         self.lambda_step = 10

--- a/mtpy/modeling/modem/convariance.py
+++ b/mtpy/modeling/modem/convariance.py
@@ -28,8 +28,24 @@ from pyevtk.hl import gridToVTK
 
 class Covariance(object):
     """
-    read and write covariance files
-
+    Class that deals with model covariance and smoothing, writing covariance
+    (.cov) files for use in ModEM.
+    
+    ==================== ======================================================
+    Attributes           Description
+    ==================== ======================================================
+    grid_dimensions      Grid dimensions excluding air layers (Nx, Ny, NzEarth)
+    smoothing_east       Smoothing in east direction. float, *default* is 0.3
+    smoothing_north      Smoothing in north direction. float, *default* is 0.3
+    smoothing_z          Smoothing in vertical direction. float, *default* is 
+                         0.3
+    smoothing_num        Number of smoothing iterations. int, *default* is 1
+    exception_list       List of exceptions. list, *default* is empty
+    mask_arr             Mask array. numpy.ndarray, *default* is None
+    save_path            Path at which to save the covariance file. PosixPath, 
+                         *default* is current working directory
+    fn_basename          Name of the covariance file. *default* is 
+                         'covariance.cov'
     """
 
     def __init__(self, grid_dimensions=None, **kwargs):
@@ -96,10 +112,28 @@ class Covariance(object):
         fn_basename=None,
         res_model=None,
         sea_water=0.3,
-        air=1e12,
-    ):  #
+        air=1.0e12,
+    ):  
         """
-        write a covariance file
+        Writes a ModEM covariance (.cov) file.
+
+        :param cov_fn: Name for the covariance file. *default* is None
+        :type cov_fn: str | Path, optional
+        :param save_path: location at which to save the covariance file. 
+            *default* is None
+        :type save_path: str | Path, optional
+        :param fn_basename: _description_, *default* is None
+        :type fn_basename: _type_, optional
+        :param res_model: Resistivity model the covariance should be generated 
+            from, *default* is None
+        :type res_model: _type_, optional
+        :param sea_water: Electrical resistivity of sea water cells in 
+            Ohm-meters within the model domain, *default* is 0.3
+        :type sea_water: float, optional
+        :param air: Electrical resistivity of air cells in Ohm-meters within 
+            the model domain, *default* is 1.0e12
+        :type air: float, optional
+        :raises CovarianceError: Error related to the covariance class.
         """
 
         if res_model is not None:
@@ -203,7 +237,11 @@ class Covariance(object):
 
     def read_cov_file(self, cov_fn):
         """
-        read a covariance file
+        Reads a ModEM covariance (.cov) file.
+
+        :param cov_fn: Filename of the target ModEM covariance (.cov) file.
+        :type cov_fn: str
+        :raises CovarianceError: Error related to the covariance class.
         """
         self.cov_fn = cov_fn
         if not self.cov_fn:

--- a/mtpy/modeling/modem/model.py
+++ b/mtpy/modeling/modem/model.py
@@ -1052,8 +1052,8 @@ class Model:
         self.grid_z += shift_z
 
         # get cell size
-        self.cell_size_east = stats.mode(self.nodes_east)[0][0]
-        self.cell_size_north = stats.mode(self.nodes_north)[0][0]
+        self.cell_size_east = stats.mode(self.nodes_east, axis=None, keepdims=True)[0][0]
+        self.cell_size_north = stats.mode(self.nodes_north, axis=None, keepdims=True)[0][0]
 
         # get number of padding cells
         self.pad_east = np.where(


### PR DESCRIPTION
## Description
Added attributes and preliminary descriptions to control_fwd, control_inv and covariance object docstrings. Ran into an error or warning using model objects, stats.mode() calls in cell_size_... assignments slightly modified.

## Motivation and Context
Clarifies usage of the ModEM module of the `mtpy-v2` package in docstrings of the major ModEM-associated classes.
