### PR TITLE
Updated default tippers to point towards a good conductor

### DIFF
--- a/mtpy/imaging/mtplot_tools/arrows.py
+++ b/mtpy/imaging/mtplot_tools/arrows.py
@@ -5,6 +5,7 @@ Created on Sun Sep 25 15:16:31 2022
 @author: jpeacock
 """
 
+
 # ==============================================================================
 # Arrows properties for induction vectors
 # ==============================================================================
@@ -36,8 +37,8 @@ class MTArrows:
                   scaling by 'size'
 
     * 'direction : [ 0 | 1 ]
-                 - 0 for arrows to point toward a conductor
-                 - 1 for arrow to point away from conductor
+                 - 0 for arrows to point away a conductor
+                 - 1 for arrow to point toward from conductor
 
     """
 
@@ -51,7 +52,9 @@ class MTArrows:
         self.arrow_threshold = 2
         self.arrow_color_imag = "c"
         self.arrow_color_real = "k"
-        self.arrow_direction = 0
+        # the data is inherently pointing away from conductor, need to flip
+        # to be in parkinson convention
+        self.arrow_direction = 1
 
         # Set class property values from kwargs and pop them
         for v in vars(self):

--- a/mtpy/imaging/mtplot_tools/plotters.py
+++ b/mtpy/imaging/mtplot_tools/plotters.py
@@ -339,6 +339,7 @@ def plot_tipper_lateral(
     font_size=6,
     legend=True,
     zero_reference=False,
+    arrow_direction=1,
 ):
     """
 
@@ -357,11 +358,19 @@ def plot_tipper_lateral(
         return None, None, None
 
     if plot_tipper.find("y") == 0 or plot_tipper:
-        txr = t_obj.mag_real * np.cos(np.deg2rad(-t_obj.angle_real))
-        tyr = t_obj.mag_real * np.sin(np.deg2rad(-t_obj.angle_real))
+        txr = t_obj.mag_real * np.cos(
+            np.deg2rad(-t_obj.angle_real) + arrow_direction * np.pi
+        )
+        tyr = t_obj.mag_real * np.sin(
+            np.deg2rad(-t_obj.angle_real) + arrow_direction * np.pi
+        )
 
-        txi = t_obj.mag_imag * np.cos(np.deg2rad(-t_obj.angle_imag))
-        tyi = t_obj.mag_imag * np.sin(np.deg2rad(-t_obj.angle_imag))
+        txi = t_obj.mag_imag * np.cos(
+            np.deg2rad(-t_obj.angle_imag) + arrow_direction * np.pi
+        )
+        tyi = t_obj.mag_imag * np.sin(
+            np.deg2rad(-t_obj.angle_imag) + arrow_direction * np.pi
+        )
 
         nt = len(txr)
         period = 1.0 / t_obj.frequency

--- a/mtpy/imaging/plot_mt_response.py
+++ b/mtpy/imaging/plot_mt_response.py
@@ -482,6 +482,7 @@ class PlotMTResponse(PlotBase):
                 self.arrow_real_properties,
                 self.arrow_imag_properties,
                 self.font_size,
+                arrow_direction=self.arrow_direction,
             )
             if self.plot_tipper.find("y") >= 0:
                 self.axt.set_xlabel("Period (s)", fontdict=self.font_dict)

--- a/mtpy/imaging/plot_mt_responses.py
+++ b/mtpy/imaging/plot_mt_responses.py
@@ -135,7 +135,6 @@ class PlotMultipleResponses(PlotBase):
     def _plot_resistivity(
         self, axr, period, z_obj, mode="od", index=0, axr2=None
     ):
-
         if mode == "od":
             comps = ["xy", "yx"]
             props = [
@@ -309,6 +308,7 @@ class PlotMultipleResponses(PlotBase):
             self.font_size,
             legend=legend,
             zero_reference=zero_reference,
+            arrow_direction=self.arrow_direction,
         )
         if axt is None:
             return None, None
@@ -331,12 +331,14 @@ class PlotMultipleResponses(PlotBase):
     ):
         # ----plot phase tensor ellipse---------------------------------------
         if self.plot_pt:
-
             color_array = self.get_pt_color_array(pt_obj)
             x_limits = self.set_period_limits(period)
 
             # -------------plot ellipses-----------------------------------
-            self.cbax, self.cbpt, = plot_pt_lateral(
+            (
+                self.cbax,
+                self.cbpt,
+            ) = plot_pt_lateral(
                 axpt,
                 pt_obj,
                 color_array,
@@ -563,12 +565,9 @@ class PlotMultipleResponses(PlotBase):
         cyx = [(1, float(cc) / ns, 0) for cc in range(ns)]
         cdet = [(0, 1 - float(cc) / ns, 0) for cc in range(ns)]
         ctipr = [
-            (0.75 * cc / ns, 0.75 * cc / ns, 0.75 * cc / ns)
-            for cc in range(ns)
+            (0.75 * cc / ns, 0.75 * cc / ns, 0.75 * cc / ns) for cc in range(ns)
         ]
-        ctipi = [
-            (float(cc) / ns, 1 - float(cc) / ns, 0.25) for cc in range(ns)
-        ]
+        ctipi = [(float(cc) / ns, 1 - float(cc) / ns, 0.25) for cc in range(ns)]
 
         # make marker lists for the different components
         mxy = ["s", "D", "x", "+", "*", "1", "3", "4"] * ns


### PR DESCRIPTION
Change the default settings to plot induction vectors to point towards a good conductor.  In measurement coordinates the induction vectors point away from a good conductor.  To plot them in Parkinson convention need to flip the sign.  This should be the default settings.

- [x] Update default plot settings
- [x] Update plotting objects 