### PR TITLE
Optimize adding TF to MTCollection

### DIFF
--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -36,7 +36,7 @@ jobs:
         conda install pytest
         conda install pytest-subtests
         conda install pytest-cov
-        pip install git+https://github.com/kujaku11/mt_metadata.git@add_pop
+        pip install git+https://github.com/kujaku11/mt_metadata.git@patches
         pip install git+https://github.com/kujaku11/mth5.git@tf_optimize
         pip install git+https://github.com/simpeg/aurora@main
         git clone https://github.com/MTgeophysics/mtpy_data.git

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -36,7 +36,7 @@ jobs:
         conda install pytest
         conda install pytest-subtests
         conda install pytest-cov
-        pip install git+https://github.com/kujaku11/mt_metadata.git@main
+        pip install git+https://github.com/kujaku11/mt_metadata.git@add_pop
         pip install git+https://github.com/kujaku11/mth5.git@tf_optimize
         pip install git+https://github.com/simpeg/aurora@main
         git clone https://github.com/MTgeophysics/mtpy_data.git

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -36,7 +36,7 @@ jobs:
         conda install pytest
         conda install pytest-subtests
         conda install pytest-cov
-        pip install git+https://github.com/kujaku11/mt_metadata.git@patches
+        pip install git+https://github.com/kujaku11/mt_metadata.git@main
         pip install git+https://github.com/kujaku11/mth5.git@tf_optimize
         pip install git+https://github.com/simpeg/aurora@main
         git clone https://github.com/MTgeophysics/mtpy_data.git

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -37,7 +37,7 @@ jobs:
         conda install pytest-subtests
         conda install pytest-cov
         pip install git+https://github.com/kujaku11/mt_metadata.git@main
-        pip install git+https://github.com/kujaku11/mth5.git@tf_optimize
+        pip install git+https://github.com/kujaku11/mth5.git@master
         pip install git+https://github.com/simpeg/aurora@main
         git clone https://github.com/MTgeophysics/mtpy_data.git
         cd mtpy_data

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -54,7 +54,7 @@ jobs:
       shell: bash
       run: |
         source activate mtpy-v2-test
-        pytest -rA --cov=./ --cov-report=xml --cov=mtpy
+        pytest --cov=./ --cov-report=xml --cov=mtpy
         
     - name: "Upload coverage to Codecov"
       uses: codecov/codecov-action@v3

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -37,7 +37,7 @@ jobs:
         conda install pytest-subtests
         conda install pytest-cov
         pip install git+https://github.com/kujaku11/mt_metadata.git@main
-        pip install git+https://github.com/kujaku11/mth5.git@master
+        pip install git+https://github.com/kujaku11/mth5.git@tf_optimize
         pip install git+https://github.com/simpeg/aurora@main
         git clone https://github.com/MTgeophysics/mtpy_data.git
         cd mtpy_data

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -379,8 +379,11 @@ class MTCollection:
         tf_group = self.mth5_collection.add_transfer_function(
             mt_object, update_metadata=update_metadata
         )
-        self.logger.debug("added %s " % mt_object.station)
-        return tf_group.parent.parent.parent.parent.attrs["id"]
+        mt_object.survey = (
+            tf_group.hdf5_group.parent.parent.parent.parent.attrs["id"]
+        )
+        self.logger.info(f"added {mt_object.survey}.{mt_object.station}")
+        return mt_object.survey
 
     def to_mt_data(self, bounding_box=None, **kwargs):
         """Get a list of transfer functions.

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -248,31 +248,36 @@ class MTCollection:
             return
         elif not isinstance(transfer_function, (list, tuple, np.ndarray)):
             transfer_function = [transfer_function]
-            
+
         surveys = []
         for item in transfer_function:
             if isinstance(item, MT):
-                self._from_mt_object(
+                survey_id = self._from_mt_object(
                     item,
                     new_survey=new_survey,
                     tf_id_extra=tf_id_extra,
-                    update_metadata=False
+                    update_metadata=False,
                 )
+                if survey_id not in surveys:
+                    surveys.append(survey_id)
             elif isinstance(item, (str, Path)):
-                self._from_file(
+                survey_id = self._from_file(
                     item,
                     new_survey=new_survey,
                     tf_id_extra=tf_id_extra,
-                    update_metadata=False
+                    update_metadata=False,
                 )
+                if survey_id not in surveys:
+                    surveys.append(survey_id)
             else:
                 raise TypeError(f"Not sure want to do with {type(item)}.")
-                
+
         if self.mth5_collection.file_version in ["0.1.0"]:
             self.mth5_collection.survey_group.update_metadata()
         else:
-            
-        self.mth5_collection.
+            for survey_id in surveys:
+                survey_group = self.mth5_collection.get_survey(survey_id)
+                survey_group.update_metadata()
         self.mth5_collection.tf_summary.summarize()
 
     def get_tf(self, tf_id, survey=None):

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -426,10 +426,11 @@ class MTCollection:
         :raises IOError: If an MTH5 is not writable raises.
         """
         if self.mth5_collection.h5_is_write():
-            for mt_obj in mt_data.values():
-                self.add_tf(
-                    mt_obj, new_survey=new_survey, tf_id_extra=tf_id_extra
-                )
+            self.add_tf(
+                list(mt_data.values()),
+                new_survey=new_survey,
+                tf_id_extra=tf_id_extra,
+            )
 
         else:
             raise IOError("MTH5 is not writeable, use 'open_mth5()'")

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -483,19 +483,18 @@ class MTCollection:
             return self.dataframe[self.dataframe.duplicated(query)]
         return None
 
-    def apply_bbox(self, lon_min, lon_max, lat_min, lat_max):
-        """Return :class:`pandas.DataFrame` of station within bounding box.
+    def apply_bbox(self, lon_min: float, lon_max: float, lat_min: float, lat_max: float) -> None:
+        """
+            Sets self.working_dataframe to only stations within bounding box.
 
-        :param lon_min: Minimum longitude.
-        :type lon_min: float
-        :param lon_max: Maximum longitude.
-        :type lon_max: float
-        :param lat_min: Minimum latitude.
-        :type lat_min: float
-        :param lat_max: Maximum longitude.
-        :type lat_max: float
-        :return: Only stations within the given bounding box.
-        :rtype: :class:`pandas.DataFrame`
+            :param lon_min: Minimum longitude.
+            :type lon_min: float
+            :param lon_max: Maximum longitude.
+            :type lon_max: float
+            :param lat_min: Minimum latitude.
+            :type lat_min: float
+            :param lat_max: Maximum longitude.
+            :type lat_max: float
         """
 
         if self.has_data():

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -140,6 +140,7 @@ class MTCollection:
     def dataframe(self):
         """This property returns the working dataframe or master dataframe if
         the working dataframe is None.
+
         :return: DESCRIPTION.
         :rtype: TYPE
         """
@@ -161,6 +162,7 @@ class MTCollection:
     @staticmethod
     def make_file_list(mt_path, file_types=["edi"]):
         """Get a list of MT file from a given path.
+
         :param file_types:
             Defaults to ["edi"].
         :param mt_path: Full path to where the MT transfer functions are stored.
@@ -198,6 +200,7 @@ class MTCollection:
         **kwargs,
     ):
         """Initialize an mth5.
+
         :param mode:
             Defaults to "a".
         :param filename:
@@ -230,6 +233,7 @@ class MTCollection:
     def add_tf(self, transfer_function, new_survey=None, tf_id_extra=None):
         """Transfer_function could be a transfer function object, a file name,
         a list of either.
+
         :param transfer_function: Transfer function object.
         :type transfer_function: list, tuple, array, MTData, MT
         :param new_survey: New survey name, defaults to None.
@@ -282,6 +286,7 @@ class MTCollection:
 
     def get_tf(self, tf_id, survey=None):
         """Get transfer function.
+
         :param survey:
             Defaults to None.
         :param tf_id: DESCRIPTION.
@@ -330,6 +335,7 @@ class MTCollection:
         self, filename, new_survey=None, tf_id_extra=None, update_metadata=True
     ):
         """Add transfer functions for a list of file names.
+
         :param filename:
         :param file_list: DESCRIPTION.
         :type file_list: TYPE
@@ -361,6 +367,7 @@ class MTCollection:
         self, mt_object, new_survey=None, tf_id_extra=None, update_metadata=True
     ):
         """From mt object.
+
         :param mt_object: DESCRIPTION.
         :type mt_object: TYPE
         :param new_survey: New survey name, defaults to None.

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -195,6 +195,7 @@ class MTCollection:
         basename=None,
         working_directory=None,
         mode="a",
+        **kwargs,
     ):
         """Initialize an mth5.
         :param mode:
@@ -217,7 +218,7 @@ class MTCollection:
         if working_directory is not None:
             self.working_directory = working_directory
 
-        self.mth5_collection.open_mth5(self.mth5_filename, mode)
+        self.mth5_collection.open_mth5(self.mth5_filename, mode, **kwargs)
 
     def close_collection(self):
         """Close mth5.

--- a/mtpy/core/mt_collection.py
+++ b/mtpy/core/mt_collection.py
@@ -225,6 +225,7 @@ class MTCollection:
 
     def close_collection(self):
         """Close mth5.
+
         :return: DESCRIPTION.
         :rtype: TYPE
         """
@@ -252,6 +253,12 @@ class MTCollection:
             return
         elif not isinstance(transfer_function, (list, tuple, np.ndarray)):
             transfer_function = [transfer_function]
+            self.logger.warning(
+                "If you are adding multiple transfer functions, suggest making "
+                "a list of transfer functions first then adding the list using "
+                "mt_collection.add_tf([list_of_tfs]). "
+                "Otherwise adding transfer functions one by one will be slow."
+            )
 
         surveys = []
         for item in transfer_function:
@@ -394,6 +401,7 @@ class MTCollection:
 
     def to_mt_data(self, bounding_box=None, **kwargs):
         """Get a list of transfer functions.
+
         :param **kwargs:
         :param tf_ids: DESCRIPTION, defaults to None.
         :type tf_ids: TYPE, optional
@@ -427,6 +435,7 @@ class MTCollection:
         useful if data have been edited or manipulated in some way.  For
         example could set 'tf_id_extra' = 'rotated' for rotated data. This will
         help you organize the tf's for each station.
+
         :param mt_data: MTData object.
         :type mt_data: :class:`mtpy.core.mt_data.MTData`
         :param new_survey: New survey name, defaults to None.
@@ -447,6 +456,7 @@ class MTCollection:
 
     def check_for_duplicates(self, locate="location", sig_figs=6):
         """Check for duplicate station locations in a MT DataFrame.
+
         :param sig_figs:
             Defaults to 6.
         :param locate:
@@ -475,18 +485,15 @@ class MTCollection:
 
     def apply_bbox(self, lon_min, lon_max, lat_min, lat_max):
         """Return :class:`pandas.DataFrame` of station within bounding box.
-        :param lat_max:
-        :param lat_min:
-        :param lon_max:
-        :param lon_min:
-        :param longitude_min: Minimum longitude.
-        :type longitude_min: float
-        :param longitude_max: Maximum longitude.
-        :type longitude_max: float
-        :param latitude_min: Minimum latitude.
-        :type latitude_min: float
-        :param latitude_max: Maximum longitude.
-        :type latitude_max: float
+
+        :param lon_min: Minimum longitude.
+        :type lon_min: float
+        :param lon_max: Maximum longitude.
+        :type lon_max: float
+        :param lat_min: Minimum latitude.
+        :type lat_min: float
+        :param lat_max: Maximum longitude.
+        :type lat_max: float
         :return: Only stations within the given bounding box.
         :rtype: :class:`pandas.DataFrame`
         """
@@ -531,15 +538,17 @@ class MTCollection:
         return gdf
 
     def to_shp(self, filename, bounding_box=None, epsg=4326):
-        """To shp.
-        :param filename: DESCRIPTION.
-        :type filename: TYPE
-        :param bounding_box: DESCRIPTION, defaults to None.
-        :type bounding_box: TYPE, optional
-        :param epsg: DESCRIPTION, defaults to 4326.
-        :type epsg: TYPE, optional
-        :return: DESCRIPTION.
-        :rtype: TYPE
+        """Create a shape file of station locations in the given EPSG number
+
+        :param filename: filename to save the shape file to.
+        :type filename: str
+        :param bounding_box: bounding box [lon_min, lon_max, lat_min, lat_max],
+         defaults to None.
+        :type bounding_box: list, optional
+        :param epsg: EPSG number to write shape file to, defaults to 4326.
+        :type epsg: int, optional
+        :return: dataframe.
+        :rtype: geopandas.DataFrame
         """
 
         if self.has_data():
@@ -558,20 +567,18 @@ class MTCollection:
         new_file=True,
     ):
         """Average nearby stations to make it easier to invert.
+
         :param new_file:
             Defaults to True.
         :param n_periods:
             Defaults to 48.
         :param count:
             Defaults to 1.
-        :param cell_size_m: DESCRIPTION.
-        :type cell_size_m: TYPE
-        :param bounding_box: DESCRIPTION, defaults to None.
-        :type bounding_box: TYPE, optional
-        :param save_dir: DESCRIPTION, defaults to None.
-        :type save_dir: TYPE, optional
-        :return: DESCRIPTION.
-        :rtype: TYPE
+        :param cell_size_m: size of square to look in for nearby stations
+        :type cell_size_m: float
+        :param bounding_box:  bounding box [lon_min, lon_max, lat_min, lat_max],
+         defaults to None.
+        :type bounding_box: list, optional
         """
 
         # cell size in degrees (bit of a hack for now)
@@ -691,6 +698,7 @@ class MTCollection:
 
     def plot_mt_response(self, tf_id, survey=None, **kwargs):
         """Plot mt response.
+
         :param survey:
             Defaults to None.
         :param tf_id: DESCRIPTION.
@@ -722,6 +730,7 @@ class MTCollection:
 
     def plot_stations(self, map_epsg=4326, bounding_box=None, **kwargs):
         """Plot stations.
+
         :param bounding_box:
             Defaults to None.
         :param map_epsg:
@@ -746,6 +755,7 @@ class MTCollection:
 
     def plot_phase_tensor(self, tf_id, survey=None, **kwargs):
         """Plot phase tensor elements.
+
         :param survey:
             Defaults to None.
         :param tf_id: DESCRIPTION.
@@ -763,6 +773,7 @@ class MTCollection:
         """Plot Phase tensor maps for transfer functions in the working_dataframe
 
         .. seealso:: :class:`mtpy.imaging.PlotPhaseTensorMaps`.
+
         :param mt_data:
             Defaults to None.
         :param **kwargs: DESCRIPTION.
@@ -781,6 +792,7 @@ class MTCollection:
         if specified
 
         .. seealso:: :class:`mtpy.imaging.PlotPhaseTensorPseudosection`
+
         :param mt_data:
             Defaults to None.
         :param **kwargs: DESCRIPTION.
@@ -798,6 +810,7 @@ class MTCollection:
         self, mt_data_01, mt_data_02, plot_type="map", **kwargs
     ):
         """Plot residual phase tensor.
+
         :param mt_data_01: DESCRIPTION.
         :type mt_data_01: TYPE
         :param mt_data_02: DESCRIPTION.
@@ -823,6 +836,7 @@ class MTCollection:
         and strike angles are interpreted for data points that are 3D.
 
         .. seealso:: :class:`mtpy.analysis.niblettbostick.calculate_depth_of_investigation`.
+
         :param survey:
             Defaults to None.
         :param tf_id:
@@ -842,6 +856,7 @@ class MTCollection:
         """Plot Penetration depth in map view for a single period
 
         .. seealso:: :class:`mtpy.imaging.PlotPenetrationDepthMap`.
+
         :param **kwargs:
         :param mt_data: DESCRIPTION, defaults to None.
         :type mt_data: TYPE, optional
@@ -859,6 +874,7 @@ class MTCollection:
         working dataframe
 
         .. seealso:: :class:`mtpy.imaging.PlotResPhaseMaps`
+
         :param mt_data:
             Defaults to None.
         :param **kwargs: DESCRIPTION.
@@ -874,6 +890,7 @@ class MTCollection:
 
     def plot_resistivity_phase_pseudosections(self, mt_data=None, **kwargs):
         """Plot resistivity and phase in a pseudosection along a profile line.
+
         :param mt_data: DESCRIPTION, defaults to None.
         :type mt_data: TYPE, optional
         :param **kwargs: DESCRIPTION.

--- a/tests/core/test_mt_collection.py
+++ b/tests/core/test_mt_collection.py
@@ -481,12 +481,12 @@ class TestMTCollection(unittest.TestCase):
                 original.station_metadata.comments = None
             if original.station_metadata.acquired_by.author in [""]:
                 original.station_metadata.acquired_by.author = None
-            if original.station_metadata.transfer_function.processing_type in [
-                ""
-            ]:
-                original.station_metadata.transfer_function.processing_type = (
-                    None
-                )
+            # if original.station_metadata.transfer_function.processing_type in [
+            #     ""
+            # ]:
+            #     original.station_metadata.transfer_function.processing_type = (
+            #         ""
+            #     )
 
             mt_data_02.add_station(original, compute_relative_location=False)
         mt_data_02.compute_relative_locations()
@@ -497,11 +497,9 @@ class TestMTCollection(unittest.TestCase):
 
         mt_data_01["CONUS_South.NMX20"].survey_metadata.update_bounding_box()
 
-        mt_data_02[
-            "unknown_survey_009.SAGE_2005_out"
-        ].station_metadata.runs = mt_data_01[
-            "unknown_survey_009.SAGE_2005_out"
-        ].station_metadata.runs
+        mt_data_02["unknown_survey_009.SAGE_2005_out"].station_metadata.runs = (
+            mt_data_01["unknown_survey_009.SAGE_2005_out"].station_metadata.runs
+        )
 
         with self.subTest("mt_data equal"):
             self.assertEqual(mt_data_01, mt_data_02)


### PR DESCRIPTION
There is a slow down when adding transfer functions to an `MTCollection`, issue #44.

The main issue seems to be that each time a transfer function is added that the survey metadata is update, which loops through all stations under it to update.  Need to add some options to skip this and just do it when all transfer functions have been added.  

Need to change a few things in `mth5` first.  PR https://github.com/kujaku11/mth5/pull/242.  

- [x] Change logic to only update survey metadata at the end of adding a bunch of transfer functions.