### PR TITLE
Pin numpy versions <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("HISTORY.rst") as history_file:
 
 
 requirements = [
-    "numpy==1.26",
+    "numpy>=1.24,<2",
     "scipy",
     "matplotlib",
     "pyproj",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("HISTORY.rst") as history_file:
 
 
 requirements = [
-    "numpy",
+    "numpy==1.26",
     "scipy",
     "matplotlib",
     "pyproj",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
 "numpy>=1.24,<2"
in setup.py.

1.24 is the highest version that is compatible with python 3.8

## Motivation and Context
When installing from git clone and then pip, which looks at setup.py, the lack of a pinned version was allowing numpy>2.  This is still a problem with simpeg, so to work around it we pin numpy <2.

## How Has This Been Tested?
Run the tests in mtpy-v2
Run the tests in aurora (which pip install mtpy-v2 from github)

## Screenshots (if appropriate):

## Types of changes
- [X ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [X] My code follows the code style of this project.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
