### PR TITLE
Patches (circular imports and fixing broken tests)

### DIFF
--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         python --version
         conda env create -f environment.yml
-        source activate mtpy-v2-test
         pip install git+https://github.com/simpeg/pydiso.git
         conda install pytest
         conda install pytest-subtests

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -38,10 +38,10 @@ jobs:
         conda install pytest
         conda install pytest-subtests
         conda install pytest-cov
-        pip install git+https://github.com/kujaku11/mt_metadata.git@main
-        pip install git+https://github.com/kujaku11/mth5.git@master
-        pip install git+https://github.com/simpeg/aurora@main
-        git clone https://github.com/MTgeophysics/mtpy_data.git
+        pip install git+https://github.com/kujaku11/mt_metadata.git@features
+        pip install git+https://github.com/kujaku11/mth5.git@features
+        pip install git+https://github.com/simpeg/aurora@features
+        git clone https://github.com/MTgeophysics/mtpy_data.git@features
         cd mtpy_data
         pip install -e .
         cd ..

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         python --version
         conda env create -f environment.yml
+        conda init --all
         conda activate mtpy-v2-test
         pip install git+https://github.com/simpeg/pydiso.git
         conda install pytest
@@ -53,6 +54,7 @@ jobs:
     - name: Run Tests
       shell: bash
       run: |
+        conda init --all
         conda activate mtpy-v2-test
         pytest --cov=./ --cov-report=xml --cov=mtpy
         

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -41,7 +41,7 @@ jobs:
         pip install git+https://github.com/kujaku11/mt_metadata.git@features
         pip install git+https://github.com/kujaku11/mth5.git@features
         pip install git+https://github.com/simpeg/aurora@features
-        git clone https://github.com/MTgeophysics/mtpy_data.git@features
+        git clone https://github.com/MTgeophysics/mtpy_data.git
         cd mtpy_data
         pip install -e .
         cd ..

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup Miniconda
-    - uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         conda-channels: conda-forge

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python --version
         conda env create -f environment.yml
-        source activate mtpy-v2-test
+        conda activate mtpy-v2-test
         pip install git+https://github.com/simpeg/pydiso.git
         conda install pytest
         conda install pytest-subtests
@@ -47,13 +47,13 @@ jobs:
     - name: Install Our Package
       shell: bash
       run: |
-        source activate mtpy-v2-test
+        conda activate mtpy-v2-test
         pip install -e .
         conda list
     - name: Run Tests
       shell: bash
       run: |
-        source activate mtpy-v2-test
+        conda activate mtpy-v2-test
         pytest --cov=./ --cov-report=xml --cov=mtpy
         
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -49,6 +49,8 @@ jobs:
     - name: Install Our Package
       shell: bash
       run: |
+        source ~/.profile
+        conda init --all
         conda activate mtpy-v2-test
         pip install -e .
         conda list

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -31,6 +31,7 @@ jobs:
       run: |
         python --version
         conda env create -f environment.yml
+        source ~/.profile
         conda init --all
         conda activate mtpy-v2-test
         pip install git+https://github.com/simpeg/pydiso.git
@@ -54,6 +55,7 @@ jobs:
     - name: Run Tests
       shell: bash
       run: |
+        source ~/.profile
         conda init --all
         conda activate mtpy-v2-test
         pytest --cov=./ --cov-report=xml --cov=mtpy

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -33,6 +33,7 @@ jobs:
       shell: bash
       run: |
         python --version
+        conda install conda-forge::cmake pkg-config mkl-devel
         conda env create -f environment.yml
         pip install git+https://github.com/simpeg/pydiso.git
         conda install pytest

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -16,13 +16,16 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+    defaults:
+      run:
+        shell: bash -el {0}
 
     steps:
     - uses: actions/checkout@v3
-    - name: Setup Conda
-      uses: s-weigand/setup-conda@v1
+    - name: Setup Miniconda
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        update-conda: false
+        auto-update-conda: true
         conda-channels: conda-forge
         python-version: ${{ matrix.python-version }}
 
@@ -47,13 +50,11 @@ jobs:
     - name: Install Our Package
       shell: bash
       run: |
-        source activate mtpy-v2-test
         pip install -e .
         conda list
     - name: Run Tests
       shell: bash
       run: |
-        source activate mtpy-v2-test
         pytest --cov=./ --cov-report=xml --cov=mtpy
         
     - name: "Upload coverage to Codecov"

--- a/.github/workflows/testing_in_conda.yml
+++ b/.github/workflows/testing_in_conda.yml
@@ -16,9 +16,6 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-    defaults:
-      run:
-        shell: bash -el {0}
 
     steps:
     - uses: actions/checkout@v3
@@ -33,8 +30,8 @@ jobs:
       shell: bash
       run: |
         python --version
-        conda install conda-forge::cmake pkg-config mkl-devel
         conda env create -f environment.yml
+        source activate mtpy-v2-test
         pip install git+https://github.com/simpeg/pydiso.git
         conda install pytest
         conda install pytest-subtests
@@ -50,11 +47,13 @@ jobs:
     - name: Install Our Package
       shell: bash
       run: |
+        source activate mtpy-v2-test
         pip install -e .
         conda list
     - name: Run Tests
       shell: bash
       run: |
+        source activate mtpy-v2-test
         pytest --cov=./ --cov-report=xml --cov=mtpy
         
     - name: "Upload coverage to Codecov"

--- a/environment.yml
+++ b/environment.yml
@@ -16,3 +16,4 @@ dependencies:
   - cmake
   - cython 
   - ninja
+  - xarray=2024.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,3 @@ dependencies:
   - cmake
   - cython 
   - ninja
-  - xarray=2024.7.0

--- a/mtpy/processing/__init__.py
+++ b/mtpy/processing/__init__.py
@@ -1,3 +1,4 @@
+from loguru import logger
 from mth5 import RUN_SUMMARY_DTYPE, RUN_SUMMARY_COLUMNS
 
 ADDED_KERNEL_DATASET_DTYPE = [
@@ -25,6 +26,11 @@ MINI_SUMMARY_COLUMNS = [
 
 from .run_summary import RunSummary
 from .kernel_dataset import KernelDataset
-from .aurora.process_aurora import AuroraProcessing
+try:
+    from .aurora.process_aurora import AuroraProcessing
+except ImportError:
+    msg = "Import from mtpy.processing.aurora failed"
+    msg = f"{msg} This is a known issue when aurora imports from mtpy"
+    logger.debug(msg)
 
 __all__ = ["RunSummary", "KernelDataset", "AuroraProcessing"]

--- a/mtpy/processing/aurora/process_aurora.py
+++ b/mtpy/processing/aurora/process_aurora.py
@@ -75,16 +75,16 @@ class AuroraProcessing(BaseProcessing):
 
         self.default_window_parameters = {
             "high": {
-                "window.overlap": 256,
-                "window.num_samples": 1024,
-                "window.type": "dpss",
-                "window.additional_args": {"alpha": 2.5},
+                "stft.window.overlap": 256,
+                "stft.window.num_samples": 1024,
+                "stft.window.type": "dpss",
+                "stft.window.additional_args": {"alpha": 2.5},
             },
             "low": {
-                "window.overlap": 64,
-                "window.num_samples": 128,
-                "window.type": "dpss",
-                "window.additional_args": {"alpha": 2.5},
+                "stft.window.overlap": 64,
+                "stft.window.num_samples": 128,
+                "stft.window.type": "dpss",
+                "stft.window.additional_args": {"alpha": 2.5},
             },
         }
 

--- a/mtpy/processing/kernel_dataset.py
+++ b/mtpy/processing/kernel_dataset.py
@@ -367,7 +367,7 @@ class KernelDataset:
 
     @property
     def processing_id(self) -> str:
-        """Its difficult to come put with unique ids without crazy long names
+        """Its difficult to come up with unique ids without crazy long names
         so this is a generic id of local-remote, the station metadata
         will have run information and the config parameters.
         """

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ with open("HISTORY.rst") as history_file:
 requirements = [
     "numpy>=1.24,<2",
     "scipy<=1.12.0",
+    "xarray==2024.7.0",
     "matplotlib",
     "pyproj",
     "configparser",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("HISTORY.rst") as history_file:
 
 requirements = [
     "numpy>=1.24,<2",
-    "scipy",
+    "scipy<=1.12.0",
     "matplotlib",
     "pyproj",
     "configparser",

--- a/tests/processing/test_kernel_dataset.py
+++ b/tests/processing/test_kernel_dataset.py
@@ -144,7 +144,8 @@ class TestKernelDataset(unittest.TestCase):
             )
 
     def test_processing_id(self):
-        self.assertEqual(self.kd.processing_id, "test1-rr_test2_sr1")
+        expected_processing_id = "test1_rr_test2_sr1"  # changed from "test1-rr_test2_sr1" 01 Mar, 2025
+        self.assertEqual(self.kd.processing_id, expected_processing_id)
 
     def test_local_survey_id(self):
         self.assertEqual("EMTF Synthetic", self.kd.local_survey_id)


### PR DESCRIPTION
## Description

I am trying to add typehinting to `aurora` and doing this has revealed some circular imports between `aurora`  and `mtpy-v2`.  I added a try/except to handle this.

But then, ... 

The tests in mtpy broke recently.  This is something to do with anaconda I think ... I looked at the test changes to mth5 and brought them over to mtpy.  A few other things had to be added because we build an environment in the mtpy tests.

Now they run, and are mostly passing but the few leftover tests will need the updates from the `features` branches currently being worked on, so I want to merge the changes here into `features`.

Alas, true test fixing will require addressing of [mt_metadata issue 253](https://github.com/kujaku11/mt_metadata/issues/253).  I added a workaround for now.  The remaining failing test passes on my local system, but fails due to interpolating complex numbers. 

@kujaku11 PTAL at the remaining test failures if you can.
